### PR TITLE
Add status bar toggle for live monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This release introduces comprehensive debugpy process management with live monitoring, auto-attach capabilities, and enhanced developer experience through visual indicators and keyboard shortcuts.
 
 The extension now provides a complete workflow for Python debugging with debugpy, from code insertion to automatic process detection and attachment. Fully compatible across Windows, macOS, and Linux platforms.
+
+### 1.2.0
+Added a status bar indicator that displays the state of live monitoring. Clicking the indicator toggles monitoring on or off.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Access these commands via `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux):
 | `Debugpy: Clean Attach Regions (Current File)` | Remove debugpy regions from active file |
 | `Debugpy: Clean All Attach Regions (Workspace)` | Remove all debugpy regions from workspace |
 
+### Status Bar Indicator
+
+The extension adds a new status bar item showing whether **Live Monitoring** is active. Click this indicator to toggle monitoring on or off.
+
 ## ⌨️ Keyboard Shortcuts
 
 | Shortcut | Action |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "debugpy-attacher",
   "displayName": "DebugPy Attacher",
   "description": "Automatically detect and attach to debugpy processes",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "DebugPyAttacher",
   "license": "MIT",
   "icon": "icon.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,10 @@ export function activate(context: vscode.ExtensionContext) {
   statusBarManager = new StatusBarManager(lockManager);
 
   // Register status bar
-  context.subscriptions.push(statusBarManager.getStatusBarItem());
+  context.subscriptions.push(
+    statusBarManager.getStatusBarItem(),
+    statusBarManager.getLiveStatusBarItem()
+  );
 
   // Register commands
   registerCommands(context);
@@ -332,6 +335,7 @@ function setupConfigurationHandling(context: vscode.ExtensionContext): void {
   const configDisposable = vscode.workspace.onDidChangeConfiguration(event => {
     if (event.affectsConfiguration('debugpyAttacher.enableLiveMonitoring')) {
       statusBarManager.restartMonitoring();
+      statusBarManager.updateLiveStatusItem();
     }
 
     if (event.affectsConfiguration('debugpyAttacher.showRulerDecorations')) {

--- a/src/statusBarManager.ts
+++ b/src/statusBarManager.ts
@@ -5,6 +5,7 @@ import { PortLockManager } from './portLockManager';
 
 export class StatusBarManager {
   private statusBarItem: vscode.StatusBarItem;
+  private liveStatusItem: vscode.StatusBarItem;
   private checkInterval: NodeJS.Timeout | undefined;
   private knownPorts = new Set<string>();
   private processService: PythonProcessService;
@@ -15,14 +16,20 @@ export class StatusBarManager {
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
     this.statusBarItem.command = 'debugpy.attachToPort';
     this.statusBarItem.tooltip = 'Click to attach to debugpy process';
-    
+
+    this.liveStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
+    this.liveStatusItem.command = 'debugpy.toggleLiveMonitoring';
+    this.liveStatusItem.tooltip = 'Toggle debugpy live monitoring';
+
     this.processService = new PythonProcessService();
     this.config = ConfigManager.getInstance();
     this.lockManager = lockManager;
+    this.updateLiveStatusItem();
   }
 
   startMonitoring(): void {
     this.lockManager.markUserActivity();
+    this.updateLiveStatusItem();
     this.updateStatusBar();
 
     if (this.config.isLiveMonitoringEnabled()) {
@@ -114,8 +121,22 @@ export class StatusBarManager {
     return this.statusBarItem;
   }
 
+  getLiveStatusBarItem(): vscode.StatusBarItem {
+    return this.liveStatusItem;
+  }
+
+  updateLiveStatusItem(): void {
+    if (this.config.isLiveMonitoringEnabled()) {
+      this.liveStatusItem.text = '$(pulse) Debugpy Live On';
+    } else {
+      this.liveStatusItem.text = '$(circle-slash) Debugpy Live Off';
+    }
+    this.liveStatusItem.show();
+  }
+
   dispose(): void {
     this.stopMonitoring();
     this.statusBarItem.dispose();
+    this.liveStatusItem.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- add a live monitoring status bar indicator
- bump extension version to 1.2.0
- document new status bar indicator in README
- note feature in changelog

## Testing
- `npm test` *(fails: Cannot find module 'vscode' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68445578a42083298aa171f5e60aa3e3